### PR TITLE
fix: prepend `cmd.exe /c` on windows to process `&&` operator

### DIFF
--- a/lua/makeit/backend.lua
+++ b/lua/makeit/backend.lua
@@ -9,9 +9,8 @@ function M.run_makefile(option)
     .. option -- run
     .. " && echo make "
     .. option -- echo
-    .. " && echo '"
+    .. " && echo "
     .. final_message
-    .. "'"
   if vim.fn.has("win32") == 1 then full_cmd = 'cmd /c "' .. full_cmd .. '"' end
 
   local task = overseer.new_task({

--- a/lua/makeit/backend.lua
+++ b/lua/makeit/backend.lua
@@ -2,18 +2,31 @@
 
 local M = {}
 
-
 function M.run_makefile(option)
   local overseer = require("overseer")
   local final_message = "--task finished--"
+  local full_cmd = "make "
+    .. option -- run
+    .. " && echo make "
+    .. option -- echo
+    .. " && echo '"
+    .. final_message
+    .. "'"
+  if vim.fn.has("win32") == 1 then full_cmd = 'cmd /c "' .. full_cmd .. '"' end
+
   local task = overseer.new_task({
     name = "- Make interpreter",
-    strategy = { "orchestrator",
-      tasks = {{ "shell", name = "- Run makefile → make " .. option ,
-          cmd = "make ".. option ..                                          -- run
-                " && echo make " .. option ..                                -- echo
-                " && echo '" .. final_message .. "'"
-      },},},})
+    strategy = {
+      "orchestrator",
+      tasks = {
+        {
+          "shell",
+          name = "- Run makefile → make " .. option,
+          cmd = full_cmd,
+        },
+      },
+    },
+  })
   task:start()
   vim.cmd("OverseerOpen")
 end


### PR DESCRIPTION
`&&` operator doesn't work on windows when the shell is set to powershell, so here I am prepending the cmd with `cmd.exe /c ` to make sure the command works even if the shell is set to something else.